### PR TITLE
changed sh to bashStandard Posix Shell only supports for varname in list

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Print an introduction line in cyan
 printf "\033[0;36mPre-commit hook is linting your changes for non-standard code...\033[0m \n"


### PR DESCRIPTION
bug fix for 
```
Pre-commit hook is linting your changes for non-standard code...
.git/hooks/pre-commit: 39: .git/hooks/pre-commit: Syntax error: Bad for loop variable
```

ref https://stackoverflow.com/questions/5627179/syntax-of-for-loop-in-linux-shell-scripting