### PR TITLE
Add bash.exe fallback from 'Git for Windows'

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash; C:/Program\ Files/Git/usr/bin/bash.exe
 
 # Print an introduction line in cyan
 printf "\033[0;36mPre-commit hook is linting your changes for non-standard code...\033[0m \n"


### PR DESCRIPTION
This should allow the pre-commit hook to work from less UNIX-y environments